### PR TITLE
Convert scons scripts to Python 3.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -113,7 +113,7 @@ BaseConf = Configure(BaseEnv,
                 'ConfigureLibJpeg' : ConfigureLibJpeg})
 
 if BaseConf.CheckCXXPresence() is None:
-    print 'error: c++ compiler not found.'
+    print('error: c++ compiler not found.')
     sys.exit(1)
 
 if BaseConf.CheckGXXSupportArgAttrUnused():
@@ -130,7 +130,7 @@ else:
     PythonIncPath = GetPythonIncPath()
 
     if PythonIncPath is not None:
-        if BaseConf.env.has_key('CPPPATH'):
+        if 'CPPPATH' in BaseConf.env:
             lastCPPPATH = BaseConf.env['CPPPATH']
         else:
             lastCPPPATH = None
@@ -146,7 +146,7 @@ else:
             del BaseConf.env['CPPPATH']
 
     if not HavePythonDev:
-        print 'Python.h not found... _ngp (Python bindings) will not be built'
+        print('Python.h not found... _ngp (Python bindings) will not be built')
 
     Endianess = BaseConf.CheckEndianess()
 
@@ -180,7 +180,7 @@ BaseConf.ConfigureGLU()
 if BaseConf.CheckCXXHeader('GL/glut.h'):
     HaveGLUTDev = True
 else:
-    print 'glut library not found - ngpview application will not be built'
+    print('glut library not found - ngpview application will not be built')
 
 GLEWInternal = BaseEnv['GLEW_INTERNAL']
 
@@ -191,7 +191,7 @@ if not GLEWInternal:
         BaseEnv.Append(GLEXT_LIBS=BaseEnv['GLEW_LIBS'])
     else:
         GLEWInternal = True
-        print 'No installed glew library found - using internal GLEW sources...'
+        print('No installed glew library found - using internal GLEW sources...')
 
 if GLEWInternal:
     BaseEnv.Append(GLEXT_INC=['#/extern/glew/include'])
@@ -235,11 +235,11 @@ if LuaEnabled:
             del LuaConfEnv
 
             if not BaseConf.CheckLuaFunc('luaL_newmetatable'):
-                print 'Lua installation seems to be broken. Using internal Lua sources...'
+                print('Lua installation seems to be broken. Using internal Lua sources...')
                 LuaInternal = True
         else:
             # Fall to internal Lua
-            print 'No installed Lua libraries found. Using internal Lua sources...'
+            print('No installed Lua libraries found. Using internal Lua sources...')
             LuaInternal = True
 
     if LuaInternal:

--- a/extern/SConscript
+++ b/extern/SConscript
@@ -11,8 +11,8 @@ lauxlib.c lbaselib.c ldblib.c liolib.c lmathlib.c loslib.c ltablib.c
 lstrlib.c loadlib.c linit.c
 """)
 
-EXTLUACORE_SRC = map(lambda a : 'lua/src/' + a,EXTLUACORE_SRC)
-EXTLUALIB_SRC = map(lambda a : 'lua/src/' + a,EXTLUALIB_SRC)
+EXTLUACORE_SRC = ['lua/src/' + a for a in EXTLUACORE_SRC]
+EXTLUALIB_SRC = ['lua/src/' + a for a in EXTLUALIB_SRC]
 
 Import('*')
 

--- a/ngplant/SConscript
+++ b/ngplant/SConscript
@@ -59,10 +59,10 @@ NGPlantEnv.Append(LIBS=NGPlantEnv['GLEXT_LIBS'])
 if TimingsEnabled:
     NGPlantEnv.Append(CPPDEFINES=[('P3D_TIMINGS_ENABLED','1')])
 
-if NGPlantEnv.has_key('PLUGINS_DIR') and NGPlantEnv['PLUGINS_DIR'] is not None:
+if 'PLUGINS_DIR' in NGPlantEnv and NGPlantEnv['PLUGINS_DIR'] is not None:
     NGPlantEnv.Append(CPPDEFINES=[('PLUGINS_DIR','\\"' + NGPlantEnv['PLUGINS_DIR'] + '\\"')])
 
-if NGPlantEnv.has_key('EXTRA_VERSION') and NGPlantEnv['EXTRA_VERSION'] is not None:
+if 'EXTRA_VERSION' in NGPlantEnv and NGPlantEnv['EXTRA_VERSION'] is not None:
     NGPlantEnv.Append(CPPDEFINES=[('EXTRA_VERSION','\\"' + NGPlantEnv['EXTRA_VERSION'] + '\\"')])
 
 if CrossCompileMode:
@@ -100,7 +100,7 @@ else:
 
     try:
         NGPlantEnv.ParseConfig(NGPlantEnv['WX_CONFIG'] + ' --cxxflags --libs --gl-libs')
-    except OSError,e:
+    except OSError as e:
         sys.stderr.write('error: wxWidgets configuration tool can not be run' +
                          '(%s),\nplease make sure that you have wxWidgets development package(s) installed\n' % (e))
         sys.exit(1)

--- a/pywrapper/SConscript
+++ b/pywrapper/SConscript
@@ -5,13 +5,13 @@ def PyDistUtilSetupCreate(target,source,env):
     if env.get('PYEXT_NAME',None) is not None:
         DistUtilSetupFile.write('ExtName = "%s"\n' % (env['PYEXT_NAME']))
     else:
-        print 'warning: PYEXT_NAME is not set - using default (pyext)'
+        print('warning: PYEXT_NAME is not set - using default (pyext)')
         DistUtilSetupFile.write('ExtName = pyext\n')
 
     if env.get('PYEXT_VERSION',None) is not None:
         DistUtilSetupFile.write('ExtVersion = "%s"\n' % (env['PYEXT_VERSION']))
     else:
-        print 'warning: PYEXT_VERSION is not set - using default ("1.0")'
+        print('warning: PYEXT_VERSION is not set - using default ("1.0")')
         DistUtilSetupFile.write('ExtVersion = "1.0"\n')
 
     DistUtilSetupFile.write('ExtSrc = []\n')

--- a/pywrapper/SConscript
+++ b/pywrapper/SConscript
@@ -1,5 +1,5 @@
 def PyDistUtilSetupCreate(target,source,env):
-    DistUtilSetupFile = file(str(target[0]),'wt')
+    DistUtilSetupFile = open(str(target[0]),'wt')
     DistUtilSetupFile.write('from distutils.core import setup,Extension\n\n')
 
     if env.get('PYEXT_NAME',None) is not None:

--- a/scripts/ngp2obj.py
+++ b/scripts/ngp2obj.py
@@ -8,15 +8,15 @@ import _ngp
 ScriptVersion = '0.9.2'
 
 def ShowUsage():
-    print 'Usage: ngp2obj.py [options] source dest'
-    print
-    print 'Convert .ngp-file \'source\' to .obj-file \'dest\''
-    print
-    print 'Options:'
-    print ' -h               - display this help and exit'
-    print ' -v               - display version information and exit'
-    print ' -t TEXPATH       - prepend TEXPATH to all texture names'
-    print
+    print('Usage: ngp2obj.py [options] source dest')
+    print()
+    print('Convert .ngp-file \'source\' to .obj-file \'dest\'')
+    print()
+    print('Options:')
+    print(' -h               - display this help and exit')
+    print(' -v               - display version information and exit')
+    print(' -t TEXPATH       - prepend TEXPATH to all texture names')
+    print()
 
 def OnInvCmdLine():
     sys.stderr.write('error: invalid command line - use \'-h\' option to get help\n')
@@ -34,7 +34,7 @@ TexturePathPrefix = ''
 
 for Option,Value in Options:
     if   Option == '-v':
-        print ScriptVersion
+        print(ScriptVersion)
         sys.exit(0)
     elif Option == '-h':
         ShowUsage();
@@ -61,7 +61,7 @@ VertexIndexOffset   = 1
 NormalIndexOffset   = 1
 TexCoordIndexOffset = 1
 
-for GroupIndex in xrange(Instance.GetGroupCount()):
+for GroupIndex in range(Instance.GetGroupCount()):
     Group    = Instance.GetGroup(GroupIndex)
     Material = Group.GetMaterial()
 
@@ -99,7 +99,7 @@ for GroupIndex in xrange(Instance.GetGroupCount()):
     NormalIndexBuffer   = Group.GetVAttrIndexBuffer(_ngp.ATTR_NORMAL,1,NormalIndexOffset)
     TexCoordIndexBuffer = Group.GetVAttrIndexBuffer(_ngp.ATTR_TEXCOORD0,1,TexCoordIndexOffset)
 
-    for PrimitiveIndex in xrange(len(VertexIndexBuffer)):
+    for PrimitiveIndex in range(len(VertexIndexBuffer)):
         vi = VertexIndexBuffer[PrimitiveIndex]
         ni = NormalIndexBuffer[PrimitiveIndex]
         ti = TexCoordIndexBuffer[PrimitiveIndex]
@@ -116,7 +116,7 @@ for GroupIndex in xrange(Instance.GetGroupCount()):
                            vi[1],ti[1],ni[1],
                            vi[2],ti[2],ni[2]))
         else:
-            raise RuntimeError,'unknown primitive type'
+            raise RuntimeError('unknown primitive type')
 
     VertexIndexOffset   += VertexIndexStep
     NormalIndexOffset   += NormalIndexStep
@@ -126,7 +126,7 @@ OBJFile.close()
 
 MTLFile = open(TargetMTLFileName,'wt')
 
-for GroupIndex in xrange(Instance.GetGroupCount()):
+for GroupIndex in range(Instance.GetGroupCount()):
     Group    = Instance.GetGroup(GroupIndex)
     Material = Group.GetMaterial()
 

--- a/sctool/SConcheck.py
+++ b/sctool/SConcheck.py
@@ -147,7 +147,7 @@ def CheckCommand(context,cmd):
     return result
 
 def GetEnvKeyOpt(Env,Key,Def = None):
-    if Env.has_key(Key):
+    if Key in Env:
         return Env[Key]
     else:
         return Def
@@ -196,14 +196,14 @@ def CheckLuaFunc(Context,FuncName):
 def ConfigureGLU(Context):
     Context.Message('Checking GLU presence and usability ... ')
 
-    if   not Context.env.has_key('GLU_INC'):
+    if   'GLU_INC' not in Context.env:
         Context.env.Append(GLU_INC=[])
     elif Context.env['GLU_INC'] != '':
         Context.env.Replace(GLU_INC=Split(Context.env['GLU_INC']))
     else:
         Context.env.Replace(GLU_INC=[])
 
-    if   not Context.env.has_key('GLU_LIBPATH'):
+    if   'GLU_LIBPATH' not in Context.env:
         Context.env.Append(GLU_LIBPATH=[])
     elif Context.env['GLU_LIBPATH'] != '':
         Context.env.Replace(GLU_LIBPATH=Split(Context.env['GLU_LIBPATH']))
@@ -215,7 +215,7 @@ def ConfigureGLU(Context):
     else:
         DefaultGLULibs=[]
 
-    if  not Context.env.has_key('GLU_LIBS'):
+    if  'GLU_LIBS' not in Context.env:
         Context.env.Append(GLU_LIBS=DefaultGLULibs)
     elif Context.env['GLU_LIBS'] != '':
         Context.env.Replace(GLU_LIBS=Split(Context.env['GLU_LIBS']))
@@ -244,21 +244,21 @@ def ConfigureGLU(Context):
 def ConfigureGLEW(Context):
     Context.Message('Checking GLEW presence and usability ... ')
 
-    if   not Context.env.has_key('GLEW_INC'):
+    if   'GLEW_INC' not in Context.env:
         Context.env.Append(GLEW_INC=[])
     elif Context.env['GLEW_INC'] != '':
         Context.env.Replace(GLEW_INC=Split(Context.env['GLEW_INC']))
     else:
         Context.env.Replace(GLEW_INC=[])
 
-    if   not Context.env.has_key('GLEW_LIBPATH'):
+    if   'GLEW_LIBPATH' not in Context.env:
         Context.env.Append(GLEW_LIBPATH=[])
     elif Context.env['GLEW_LIBPATH'] != '':
         Context.env.Replace(GLEW_LIBPATH=Split(Context.env['GLEW_LIBPATH']))
     else:
         Context.env.Replace(GLEW_LIBPATH=[])
 
-    if  not Context.env.has_key('GLEW_LIBS'):
+    if  'GLEW_LIBS' not in Context.env:
         Context.env.Append(GLEW_LIBS=['GLEW'])
     elif Context.env['GLEW_LIBS'] != '':
         Context.env.Replace(GLEW_LIBS=Split(Context.env['GLEW_LIBS']))
@@ -290,7 +290,7 @@ def ConfigureGLEW(Context):
     return Ret
 
 def SubtractLists(a,b):
-    return filter(lambda i : i not in b,a)
+    return [i for i in a if i not in b]
 
 P3DCheckLibPngUsabilitySrc = """
 #include <png.h>


### PR DESCRIPTION
Currently the build files use Python 2, which is not supported by recent versions of Scons (nor is the interpreter itself supported). I ran `2to3` on the Scons build files, and I manually replaced `file` with `open`. After these changes, it built successfully on Ubuntu 21.04.

Running the tools seemed to work, too. I did have some WxWidgets errors regarding a invalid DC that didn't seem to interfere with the running of the program and seem unrelated.